### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ First of all choose and configure test LTI 1.3 Platform. It may be:
 The most simple way to check example is to use ``docker`` + ``docker-compose``.
 Change the necessary configs in the ``examples/configs/game.json`` (`here is instruction`_ how to generate your own public + private keys):
 
-.. _here is instruction: https://github.com/dmitry-viskov/pylti1.3/wiki/How-to-generate-JWT-RS256-key-and-JWKS
+.. _here is instruction:  https://github.com/dmitry-viskov/pylti1.3/wiki/How-to-generate-JWT-RS256-key-and-JWKS
 
 .. code-block:: javascript
 


### PR DESCRIPTION
As I can't fork and edit the wiki for "How to generate JWT RS256 key and JWKS," I do small change to the README  to suggest a code change to the scrip.
 jwk_obj = JWK.from_pem(public_key.encode('UTF-8')) 
# eliminates the error "cannot return the address of a unicode object from being thrown."