### PR TITLE
Detect Transient LTI Launch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -379,6 +379,7 @@ Check user's role after LTI launch
     user_is_teaching_assistant = message_launch.check_teaching_assistant_access()
     user_is_designer = message_launch.check_designer_access()
     user_is_observer = message_launch.check_observer_access()
+    user_is_transient = message_launch.check_transient()
 
 Usage with Flask
 ================

--- a/pylti1p3/message_launch.py
+++ b/pylti1p3/message_launch.py
@@ -17,7 +17,8 @@ from .exception import LtiException
 from .launch_data_storage.base import DisableSessionId
 from .message_validators import get_validators
 from .names_roles import NamesRolesProvisioningService
-from .roles import StaffRole, StudentRole, TeacherRole, TeachingAssistantRole, DesignerRole, ObserverRole
+from .roles import StaffRole, StudentRole, TeacherRole, TeachingAssistantRole, DesignerRole, ObserverRole, \
+    TransientRole
 from .service_connector import ServiceConnector
 from .utils import encode_on_py3
 
@@ -684,3 +685,8 @@ class MessageLaunch(t.Generic[REQ, TCONF, SES, COOK]):
         # type: () -> bool
         jwt_body = self._get_jwt_body()
         return ObserverRole(jwt_body).check()
+
+    def check_transient(self):
+        # type: () -> bool
+        jwt_body = self._get_jwt_body()
+        return TransientRole(jwt_body).check()

--- a/pylti1p3/roles.py
+++ b/pylti1p3/roles.py
@@ -86,3 +86,10 @@ class DesignerRole(AbstractRole):
 class ObserverRole(AbstractRole):
     _common_roles = ('Mentor',)  # type: tuple
     _context_roles = ('Mentor',)  # type: tuple
+
+
+class TransientRole(AbstractRole):
+    _common_roles = ('Transient',)  # type: tuple
+    _system_roles = ('Transient',)  # type: tuple
+    _institution_roles = ('Transient',)  # type: tuple
+    _context_roles = ('Transient',)  # type: tuple


### PR DESCRIPTION
This is useful when attempting to check if a user that has
performed a message launch into an LTI Tool from a Platform
is impersonating a user.

IMS Spec: http://www.imsglobal.org/lti-when-user-not-real-user

Issue: https://github.com/dmitry-viskov/pylti1.3/issues/26