### PR TITLE
Fix requirements so typing library doesn't shadow stdlib version on P…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,13 +15,9 @@ if sys.version_info < (2, 7):
 install_requires = [
     'pyjwt>=1.5',
     'jwcrypto',
-    'requests'
+    'requests',
+    'typing;python_version<"3.5"'
 ]
-
-if sys.version_info < (3, 5):
-    extra_pkgs = ['typing']
-else:
-    extra_pkgs = []
 
 with open("README.rst", "rt") as readme:
     long_description = readme.read().strip()
@@ -37,7 +33,7 @@ setup(
     author_email='dmitry.viskov@webenterprise.ru',
     maintainer="Dmitry Viskov",
     long_description=long_description,
-    install_requires=install_requires + extra_pkgs,
+    install_requires=install_requires,
     license='MIT',
     url='https://github.com/dmitry-viskov/pylti1.3',
     packages=packages,


### PR DESCRIPTION
…ython 3.5+

This PR is the result of me spending a few hours debugging a weird issue on a Lambda. It seems that the wheel file presently published for 1.8.1 includes in its metadata the typing library requirement (presumably, it was built with Python <3.5), causing it to be installed locally even on Python 3.5+. This is fine in development, but once the lambda is packaged and deployed, both Serverless and Zappa put dependencies at the root level of the package, so they shadow the stdlib's version of the typing library. This in turn made otherwise innocuous calls into the stdlib call the PyPI version of typing, raising exceptions due to version incompatibilities.

This PR fixes that by conditionally installing typing on Py <3.5 through the requirement spec, not in-code logic, which is the approach recommended by the maintainers of typing. See last paragraph of this page for details: https://pypi.org/project/typing/

This has been tested to work with PIP. As in, given a requirements file and a wheel dir with a wheel built with this PR applied, PIP will install the package cleanly without typing.