### PR TITLE
Improve handling of http responses

### DIFF
--- a/pylti1p3/exception.py
+++ b/pylti1p3/exception.py
@@ -23,11 +23,3 @@ class LtiServiceException(LtiException):
         )
         super(LtiServiceException, self).__init__(msg)
         self.response = response
-
-    @classmethod
-    def maybe_raise(cls, response):
-        # type: (requests.Response) -> None
-        """Raise an ``LtiServiceException`` when the response is not ``ok``.
-        """
-        if not response.ok:
-            raise cls(response)

--- a/pylti1p3/exception.py
+++ b/pylti1p3/exception.py
@@ -1,6 +1,33 @@
+import typing as t
+
+if t.TYPE_CHECKING:
+    # pylint: disable=unused-import
+    import requests
+
+
 class LtiException(Exception):
     pass
 
 
 class OIDCException(Exception):
     pass
+
+
+class LtiServiceException(LtiException):
+    def __init__(self, response):
+        # type: (requests.Response) -> None
+        msg = 'HTTP response [%s]: %s - %s' % (
+            response.url,
+            str(response.status_code),
+            response.text,
+        )
+        super(LtiServiceException, self).__init__(msg)
+        self.response = response
+
+    @classmethod
+    def maybe_raise(cls, response):
+        # type: (requests.Response) -> None
+        """Raise an ``LtiServiceException`` when the response is not ``ok``.
+        """
+        if not response.ok:
+            raise cls(response)

--- a/pylti1p3/service_connector.py
+++ b/pylti1p3/service_connector.py
@@ -14,12 +14,10 @@ if t.TYPE_CHECKING:
 
     from .registration import Registration
 
-    _ServiceConnectorResponse = TypedDict(
-        '_ServiceConnectorResponse', {
-            'headers': t.Dict[str, str],
-            'body': t.Union[None, int, float, t.List[object], t.
-                            Dict[str, object], str],
-        })
+    _ServiceConnectorResponse = TypedDict('_ServiceConnectorResponse', {
+        'headers': t.Dict[str, str],
+        'body': t.Union[None, int, float, t.List[object], t.Dict[str, object], str],
+    })
 
 
 class ServiceConnector(object):

--- a/pylti1p3/service_connector.py
+++ b/pylti1p3/service_connector.py
@@ -16,11 +16,9 @@ if t.TYPE_CHECKING:
 
     _ServiceConnectorResponse = TypedDict(
         '_ServiceConnectorResponse', {
-            'headers':
-            t.Dict[str, str],
-            'body':
-            t.Union[None, int, float, t.List[object], t.
-                    Dict[str, object], str],
+            'headers': t.Dict[str, str],
+            'body': t.Union[None, int, float, t.List[object], t.
+                            Dict[str, object], str],
         })
 
 
@@ -76,23 +74,22 @@ class ServiceConnector(object):
 
         auth_request = {
             'grant_type': 'client_credentials',
-            'client_assertion_type':
-            'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+            'client_assertion_type': 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
             'client_assertion': jwt_val,
             'scope': ' '.join(scopes)
         }
 
         # Make request to get auth token
         r = requests.post(auth_url, data=auth_request)
-        LtiServiceException.maybe_raise(r)
+        if not r.ok:
+            raise LtiServiceException(r)
         response = r.json()
 
         self._access_tokens[scope_key] = response['access_token']
         return self._access_tokens[scope_key]
 
     def encode_jwt(self, message, private_key, headers):
-        jwt_val = jwt.encode(
-            message, private_key, algorithm='RS256', headers=headers)
+        jwt_val = jwt.encode(message, private_key, algorithm='RS256', headers=headers)
         if sys.version_info[0] > 2 and isinstance(jwt_val, bytes):
             return jwt_val.decode('utf-8')
         return jwt_val
@@ -108,7 +105,10 @@ class ServiceConnector(object):
     ):
         # type: (...) -> _ServiceConnectorResponse
         access_token = self.get_access_token(scopes)
-        headers = {'Authorization': 'Bearer ' + access_token, 'Accept': accept}
+        headers = {
+            'Authorization': 'Bearer ' + access_token,
+            'Accept': accept
+        }
 
         if is_post:
             headers['Content-Type'] = content_type
@@ -117,7 +117,8 @@ class ServiceConnector(object):
         else:
             r = requests.get(url, headers=headers)
 
-        LtiServiceException.maybe_raise(r)
+        if not r.ok:
+            raise LtiServiceException(r)
 
         return {
             'headers': dict(r.headers),


### PR DESCRIPTION
This fixes two issues. First some requests would raise if the response was 204,
which for example Brightspace returns when posting scores. The second was that
the actual response could be accessed, which makes custom handling of these
exceptions difficult.