### PR TITLE
Fix paging sometimes broken in NRPS

### DIFF
--- a/pylti1p3/names_roles.py
+++ b/pylti1p3/names_roles.py
@@ -48,8 +48,13 @@ class NamesRolesProvisioningService(object):
 
             members.extend(t.cast(t.Any, page.get('body', {})).get('members', []))
 
+            link_header = ''
+            for header, header_value in page.get('headers', {}).items():
+                if header.lower() == 'link':
+                    link_header = header_value
+                    break
+
             next_page = False
-            link_header = page.get('headers', {}).get('link', '')
             if link_header:
                 match = re.search(r'<([^>]*)>;\s*rel="next"', link_header.replace('\n', ' ').lower().strip())
                 if match:


### PR DESCRIPTION
It appears that the functionality in `NamesRolesProvisioningService` to page through and retrieve all results, is sometimes broken and will only retrieve the first page.

This happens whenever the link header in the response is not written in lowercase as "link"; the method will ignore a "Link" header and not retrieve subsequent pages.

The original code perhaps assumes that it's handling what is usually a [CaseInsensitiveDict](https://github.com/psf/requests/blob/2aab9a9a39fdfdfbd37cc8494259cb0ebb36a5e9/requests/structures.py#L15) from `response.headers`, but in fact it is unpackaged into a typical dict [here](https://github.com/dmitry-viskov/pylti1.3/blob/c242c24393e02216a8470ee285ab7c9e7cc349f8/pylti1p3/service_connector.py#L122). This causes the original case of the header to be preserved. Hence a lookup for "link" will fail if the original header was "Link". See this code example below:

```python
from requests.structures import CaseInsensitiveDict

dict(CaseInsensitiveDict([("link", "lowercase")]))
# {'link': 'lowercase'}

dict(CaseInsensitiveDict([("Link", "capitalized")]))
# {'Link': 'capitalized'}
```

In the attached commit, a case-insensitive lookup is used.

No other similar cases were found in the project. 

It was tested to fix such an issue found with Canvas LMS.

Feel free to make any changes to the PR.
