### PR TITLE
Allow caller to pass a python-requests Session object to use

### DIFF
--- a/pylti1p3/contrib/django/message_launch.py
+++ b/pylti1p3/contrib/django/message_launch.py
@@ -7,12 +7,12 @@ from .session import DjangoSessionService
 
 class DjangoMessageLaunch(MessageLaunch):
 
-    def __init__(self, request, tool_config, session_service=None, cookie_service=None, launch_data_storage=None):
+    def __init__(self, request, tool_config, session_service=None, cookie_service=None, launch_data_storage=None, requests_session=None):
         django_request = request if isinstance(request, Request) else DjangoRequest(request, post_only=True)
         cookie_service = cookie_service if cookie_service else DjangoCookieService(django_request)
         session_service = session_service if session_service else DjangoSessionService(request)
         super(DjangoMessageLaunch, self).__init__(django_request, tool_config, session_service, cookie_service,
-                                                  launch_data_storage)
+                                                  launch_data_storage, requests_session)
 
     def _get_request_param(self, key):
         return self._request.get_param(key)

--- a/pylti1p3/contrib/flask/message_launch.py
+++ b/pylti1p3/contrib/flask/message_launch.py
@@ -5,11 +5,11 @@ from .session import FlaskSessionService
 
 class FlaskMessageLaunch(MessageLaunch):
 
-    def __init__(self, request, tool_config, session_service=None, cookie_service=None, launch_data_storage=None):
+    def __init__(self, request, tool_config, session_service=None, cookie_service=None, launch_data_storage=None, requests_session=None):
         cookie_service = cookie_service if cookie_service else FlaskCookieService(request)
         session_service = session_service if session_service else FlaskSessionService(request)
         super(FlaskMessageLaunch, self).__init__(request, tool_config, session_service, cookie_service,
-                                                 launch_data_storage)
+                                                 launch_data_storage, requests_session)
 
     def _get_request_param(self, key):
         return self._request.get_param(key)

--- a/pylti1p3/message_launch.py
+++ b/pylti1p3/message_launch.py
@@ -191,8 +191,8 @@ class MessageLaunch(t.Generic[REQ, TCONF, SES, COOK]):
     _public_key_cache_data_storage = None  # type: t.Optional[LaunchDataStorage[t.Any]]
     _public_key_cache_lifetime = None  # type: t.Optional[int]
 
-    def __init__(self, request, tool_config, session_service, cookie_service, launch_data_storage=None):
-        # type: (REQ, TCONF, SES, COOK, t.Optional[LaunchDataStorage[t.Any]]) -> None
+    def __init__(self, request, tool_config, session_service, cookie_service, launch_data_storage=None, requests_session=None):
+        # type: (REQ, TCONF, SES, COOK, t.Optional[LaunchDataStorage[t.Any], t.Optional[Session]]) -> None
         self._request = request
         self._tool_config = tool_config
         self._session_service = session_service
@@ -206,6 +206,7 @@ class MessageLaunch(t.Generic[REQ, TCONF, SES, COOK]):
         self._restored = False
         self._public_key_cache_data_storage = None
         self._public_key_cache_lifetime = None
+        self._requests_session = requests_session
 
         if launch_data_storage:
             self.set_launch_data_storage(launch_data_storage)
@@ -259,10 +260,10 @@ class MessageLaunch(t.Generic[REQ, TCONF, SES, COOK]):
 
     @classmethod
     def from_cache(cls, launch_id, request, tool_config, session_service=None, cookie_service=None,
-                   launch_data_storage=None):
+                   launch_data_storage=None, requests_session=None):
         # type: (t.Type[T_SELF], str, REQ, TCONF, SES, COOK, t.Optional[LaunchDataStorage[t.Any]]) -> T_SELF
         obj = cls(request, tool_config, session_service=session_service, cookie_service=cookie_service,
-                  launch_data_storage=launch_data_storage)
+                  launch_data_storage=launch_data_storage, requests_session=requests_session)
         launch_data = obj.get_session_service().get_launch_data(launch_id)
         if not launch_data:
             raise LtiException("Launch data not found")
@@ -346,7 +347,7 @@ class MessageLaunch(t.Generic[REQ, TCONF, SES, COOK]):
         :return: NamesRolesProvisioningService
         """
         assert self._registration is not None, 'Registration not yet set'
-        connector = ServiceConnector(self._registration)
+        connector = ServiceConnector(self._registration, self._requests_session)
         names_role_service = self._get_jwt_body()\
             .get('https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice')
         if not names_role_service:
@@ -370,7 +371,7 @@ class MessageLaunch(t.Generic[REQ, TCONF, SES, COOK]):
         :return: AssignmentsGradesService
         """
         assert self._registration is not None, 'Registration not yet set'
-        connector = ServiceConnector(self._registration)
+        connector = ServiceConnector(self._registration, self._requests_session)
         endpoint = self._get_jwt_body() \
             .get('https://purl.imsglobal.org/spec/lti-ags/claim/endpoint')
         if not endpoint:
@@ -394,7 +395,7 @@ class MessageLaunch(t.Generic[REQ, TCONF, SES, COOK]):
         :return:
         """
         assert self._registration is not None, 'Registration not yet set'
-        connector = ServiceConnector(self._registration)
+        connector = ServiceConnector(self._registration, self._requests_session)
         groups_service_data = self._get_jwt_body() \
             .get('https://purl.imsglobal.org/spec/lti-gs/claim/groupsservice')
         if not groups_service_data:
@@ -535,7 +536,7 @@ class MessageLaunch(t.Generic[REQ, TCONF, SES, COOK]):
                     return public_key
 
             try:
-                resp = requests.get(key_set_url)
+                resp = (self._requests_session or requests).get(key_set_url)
             except requests.exceptions.RequestException as e:
                 raise LtiException("Error during fetch URL " + key_set_url + ": " + str(e))
             try:
@@ -787,3 +788,8 @@ class MessageLaunch(t.Generic[REQ, TCONF, SES, COOK]):
         # type: () -> bool
         jwt_body = self._get_jwt_body()
         return TransientRole(jwt_body).check()
+
+    def set_requests_session(self, session):
+        # type: (T_SELF, Session) -> T_SELF
+        self._requests_session = session
+        return self

--- a/pylti1p3/service_connector.py
+++ b/pylti1p3/service_connector.py
@@ -24,11 +24,13 @@ if t.TYPE_CHECKING:
 class ServiceConnector(object):
     _registration = None  # type: Registration
     _access_tokens = None  # type: t.Dict[str, str]
+    _requests_session = None  # type: Session
 
-    def __init__(self, registration):
+    def __init__(self, registration, requests_session=None):
         # type: (Registration) -> None
         self._registration = registration
         self._access_tokens = {}
+        self._requests_session = requests_session
 
     def get_access_token(self, scopes):
         # type: (t.Sequence[str]) -> str
@@ -79,7 +81,7 @@ class ServiceConnector(object):
         }
 
         # Make request to get auth token
-        r = requests.post(auth_url, data=auth_request)
+        r = (self._requests_session or requests).post(auth_url, data=auth_request)
         if not r.ok:
             raise LtiServiceException(r)
         response = r.json()
@@ -113,9 +115,9 @@ class ServiceConnector(object):
         if is_post:
             headers['Content-Type'] = content_type
             post_data = data or None
-            r = requests.post(url, data=post_data, headers=headers)
+            r = (self._requests_session or requests).post(url, data=post_data, headers=headers)
         else:
-            r = requests.get(url, headers=headers)
+            r = (self._requests_session or requests).get(url, headers=headers)
 
         if not r.ok:
             raise LtiServiceException(r)


### PR DESCRIPTION
This PR allows the caller to pass in a requests.Session object to use for HTTP requests (tokens, keys, service connectors). This is useful to:

- pass custom headers, like User-Agent (otherwise all outbound requests get the default requests user-agent)
- configure proxies
- use caching, via requests-cache's CachedSession (relates to #90)
