### PR TITLE
only decode service data as JSON if content-type says so

### DIFF
--- a/pylti1p3/service_connector.py
+++ b/pylti1p3/service_connector.py
@@ -129,6 +129,6 @@ class ServiceConnector(object):
 
         return {
             'headers': r.headers if case_insensitive_headers else dict(r.headers),
-            'body': r.json() if r.content else None,
+            'body': r.json() if r.content and r.headers['content-type'].partition(';')[0].lower() == 'application/json' else r.content,
             'next_page_url': next_page_url if next_page_url else None
         }


### PR DESCRIPTION
The ServiceConnector should check the returned content-type before decoding the body as JSON. LTI 1.3 allows the 1.0/1.1 basic outcomes service to be used as a 1.3 service, but it returns XML. 