### PR TITLE
fix handling when lineitem is passed that already has ID

### DIFF
--- a/pylti1p3/assignments_grades.py
+++ b/pylti1p3/assignments_grades.py
@@ -55,8 +55,9 @@ class AssignmentsGradesService(object):
         if not self.can_put_grade():
             raise LtiException("Can't put grade: Missing required scope")
 
-        if lineitem and not lineitem.get_id():
-            lineitem = self.find_or_create_lineitem(lineitem)
+        if lineitem:
+            if not lineitem.get_id():
+                lineitem = self.find_or_create_lineitem(lineitem)
             score_url = lineitem.get_id()
         elif not lineitem and self._service_data.get('lineitem'):
             score_url = self._service_data.get('lineitem')


### PR DESCRIPTION
If you call put_grade with a lineitem that has an ID set, you get an exception `Can't find lineitem to put grade`, because there is no handling for this case since the refactoring.