### PR TITLE
Fix check for reading line items

### DIFF
--- a/pylti1p3/assignments_grades.py
+++ b/pylti1p3/assignments_grades.py
@@ -29,7 +29,10 @@ class AssignmentsGradesService(object):
         self._service_data = service_data
 
     def can_read_lineitem(self):
-        return "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly" in self._service_data['scope']
+        return (
+            "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly" in self._service_data['scope']
+            or "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem" in self._service_data['scope']
+        )
 
     def can_create_lineitem(self):
         return "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem" in self._service_data['scope']


### PR DESCRIPTION
Since upgrading from 1.11.0 to 1.12.1, we have noticed that our AGS line item requests are failing:

```python
assignments_grades_service.find_or_create_lineitem_by_resource_id(lineitem)
# LtiException: Can't read lineitem: Missing required scope
```

Here's what our scope contains:

```python
print(assignments_grades_service._service_data)

{'scope': ['https://purl.imsglobal.org/spec/lti-ags/scope/lineitem',
 'https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly',
 'https://purl.imsglobal.org/spec/lti-ags/scope/score'],
 'lineitems': 'https://example.com/lti-ags/context/123412341234/lineitems',
 'lineitem': None}
```

You'll notice we have `https://purl.imsglobal.org/spec/lti-ags/scope/lineitem` in the scope but not `https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly` which is what is checked by `AssignmentsGradesService.can_read_lineitem()`.

According to the [relevant AGS spec](https://www.imsglobal.org/spec/lti-ags/v2p0#line-item-service-scope-and-allowed-http-methods): the ability to read line items is also granted with the scope entry `https://purl.imsglobal.org/spec/lti-ags/scope/lineitem`:

<img width="807" alt="Screen Shot 2022-11-07 at 4 37 39 pm" src="https://user-images.githubusercontent.com/235466/200234146-f8251e68-0f89-40be-ac52-29cdaee9a288.png">

We've checked that with this PR, it no longer raises this error in this situation.
