### PR TITLE
Raise specific exceptions in tool configuration

### DIFF
--- a/pylti1p3/exception.py
+++ b/pylti1p3/exception.py
@@ -5,7 +5,11 @@ class LtiException(Exception):
     pass
 
 
-class OIDCException(Exception):
+class LtiConfigurationException(LtiException):
+    pass
+
+
+class OIDCException(LtiException):
     pass
 
 

--- a/pylti1p3/lineitem.py
+++ b/pylti1p3/lineitem.py
@@ -176,7 +176,7 @@ class LineItem:
         custom: t.Optional[t.Dict[str, str]] = None,
     ) -> "LineItem":
         if not isinstance(reviewable_status, list):
-            raise Exception('Invalid "reviewable_status" argument')
+            raise ValueError('Invalid "reviewable_status" argument')
 
         self._submission_review: TSubmissionReview = {
             "reviewableStatus": reviewable_status

--- a/pylti1p3/tool_config/abstract.py
+++ b/pylti1p3/tool_config/abstract.py
@@ -2,6 +2,7 @@ import typing as t
 from abc import ABCMeta, abstractmethod
 import typing_extensions as te
 from ..deployment import Deployment
+from ..exception import LtiConfigurationException
 from ..registration import Registration
 from ..request import Request
 
@@ -109,9 +110,9 @@ class ToolConfAbstract(t.Generic[REQ]):
                 reg = self.find_registration(iss)
             elif self.check_iss_has_many_clients(iss):
                 if not client_id:
-                    raise Exception("client_id is not specified")
+                    raise LtiConfigurationException("client_id is not specified")
                 reg = self.find_registration_by_params(iss, client_id, **kwargs)
             else:
-                raise Exception("Invalid issuer relation type")
+                raise LtiConfigurationException("Invalid issuer relation type")
             keys = reg.get_jwks()
         return {"keys": keys}

--- a/pylti1p3/tool_config/json_file.py
+++ b/pylti1p3/tool_config/json_file.py
@@ -2,6 +2,7 @@ import typing as t
 import json
 import os
 
+from ..exception import LtiConfigurationException
 from .dict import ToolConfDict, TIssConf, TJsonData
 
 
@@ -61,7 +62,9 @@ class ToolConfJsonFile(ToolConfDict):
         deployment_ids (list) - The deployment_id passed by the platform during launch
         """
         if not os.path.isfile(config_file):
-            raise Exception("LTI tool config file not found: " + config_file)
+            raise LtiConfigurationException(
+                f"LTI tool config file not found: {config_file}"
+            )
         self._configs_dir = os.path.dirname(config_file)
 
         with open(config_file, encoding="utf-8") as cfg:
@@ -83,7 +86,9 @@ class ToolConfJsonFile(ToolConfDict):
     ):
         private_key_file = iss_conf.get("private_key_file")
         if not private_key_file:
-            raise Exception("iss config error: private_key_file not found")
+            raise LtiConfigurationException(
+                "iss config error: private_key_file not found"
+            )
 
         if not private_key_file.startswith("/"):
             private_key_file = self._configs_dir + "/" + private_key_file


### PR DESCRIPTION
Hello,

I'm suggesting to use a dedicated exception class for all exceptions raised in the tool configuration files in order to be able to catch these exceptions when using the project.

I also suggest to use the `LtiException` as base class for `OIDCException` in order to have all exceptions with the same base class.

Regards