### PR TITLE
Add iframe support to DeepLinkResource

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -9,8 +9,8 @@ jobs:
         python: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v3.3.0
+      - uses: actions/setup-python@v4.5.0
         with:
           python-version: ${{ matrix.python }}
       - run: pip install --upgrade pip

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         python: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
     runs-on: ${{ matrix.os }}
     steps:

--- a/pylti1p3/contrib/django/lti1p3_tool_config/migrations/0001_initial.py
+++ b/pylti1p3/contrib/django/lti1p3_tool_config/migrations/0001_initial.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/pylti1p3/deep_link_resource.py
+++ b/pylti1p3/deep_link_resource.py
@@ -8,6 +8,7 @@ class DeepLinkResource:
     _url: t.Optional[str] = None
     _lineitem: t.Optional[LineItem] = None
     _custom_params: t.Mapping[str, str] = {}
+    _iframe: t.Mapping[str, int] = {}
     _target: str = "iframe"
     _icon_url: t.Optional[str] = None
 
@@ -60,6 +61,13 @@ class DeepLinkResource:
         self._icon_url = value
         return self
 
+    def get_iframe(self) -> t.Mapping[str, int]:
+        return self._iframe
+
+    def set_iframe(self, value: t.Mapping[str, int]):
+        self._iframe = value
+        return self
+
     def to_dict(self) -> t.Dict[str, object]:
         res: t.Dict[str, object] = {
             "type": self._type,
@@ -92,5 +100,8 @@ class DeepLinkResource:
 
         if self._icon_url:
             res["icon"] = {"url": self._icon_url}
+
+        if self._iframe:
+            res["iframe"] = self._iframe
 
         return res

--- a/pylti1p3/deployment.py
+++ b/pylti1p3/deployment.py
@@ -2,7 +2,6 @@ import typing as t
 
 
 class Deployment:
-
     _deployment_id: t.Optional[str] = None
 
     def get_deployment_id(self) -> t.Optional[str]:

--- a/tests/test_deep_link.py
+++ b/tests/test_deep_link.py
@@ -167,7 +167,6 @@ class DeepLinkBase(TestLinkBase):
         ).get("deep_link_return_url")
 
         html = validated_message_launch.get_deep_link().output_response_form([resource])
-        print(html)
         self.assertTrue(
             html.startswith(
                 f'<form id="lti13_deep_link_auto_submit" action="{deep_link_return_url}" '

--- a/tests/test_deep_link.py
+++ b/tests/test_deep_link.py
@@ -160,13 +160,14 @@ class DeepLinkBase(TestLinkBase):
         resource = DeepLinkResource()
         resource.set_url("http://lti.django.test/launch/").set_custom_params(
             {"custom_param": "custom_value"}
-        ).set_title("Test title!")
+        ).set_title("Test title!").set_iframe({"width": 800, "height": 400})
 
         deep_link_return_url = message_launch_data.get(
             "https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings"
         ).get("deep_link_return_url")
 
         html = validated_message_launch.get_deep_link().output_response_form([resource])
+        print(html)
         self.assertTrue(
             html.startswith(
                 f'<form id="lti13_deep_link_auto_submit" action="{deep_link_return_url}" '

--- a/tests/test_resource_link.py
+++ b/tests/test_resource_link.py
@@ -299,7 +299,6 @@ class ResourceLinkBase(TestLinkBase):
         return message_launch_data
 
     def test_res_link_launch_invalid_nonce(self):
-
         tool_conf, login_request, login_response = self._make_oidc_login()
 
         post_data = self.post_launch_data.copy()

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
     mypy
     parameterized
     pyjwt
-    pylint
+    pylint==2.15.6
     requests
     requests-mock
     types-requests

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
     mypy
     parameterized
     pyjwt
-    pylint
+    pylint<2.15.6
     requests
     requests-mock
     types-requests

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
     mypy
     parameterized
     pyjwt
-    pylint==2.15.6
+    pylint
     requests
     requests-mock
     types-requests


### PR DESCRIPTION
This PR modifies the `DeepLinkResource` class to add support for the `iframe` property as described in the [LTI 1.3 spec](https://www.imsglobal.org/spec/lti-dl/v2p0#lti-resource-link). When set, this property indicates to the platform that the resource content can be embedded in a platform page using an iframe. 

Usage:
```
    resource = DeepLinkResource()
    resource.set_url("https://my.tool/launch")\
        .set_custom_params({'my_param': my_param})\
        .set_title('My Resource')
        .set_iframe({"height": 400, "width": 800})
```

This PR also adjust some test settings in `tox.ini` and `tox.yml` in order to fix failing tests.

Closes #111.