### PR TITLE
Don't send custom parameters if empty in deep linking result

### DIFF
--- a/pylti1p3/deep_link_resource.py
+++ b/pylti1p3/deep_link_resource.py
@@ -65,7 +65,6 @@ class DeepLinkResource:
             "type": self._type,
             "title": self._title,
             "url": self._url,
-            "custom": self._custom_params,
         }
         if self._lineitem:
             line_item: t.Dict[str, object] = {
@@ -92,5 +91,8 @@ class DeepLinkResource:
 
         if self._icon_url:
             res["icon"] = {"url": self._icon_url}
+
+        if self._custom_params:
+            res["custom"] = self._custom_params
 
         return res


### PR DESCRIPTION
Moodle 4.1 is upset by an empty custom parameter object in the deep linking result. This is probably a bug in Moodle, but there is no reason to send the custom parameters claim if it is empty.