### PR TITLE
Change incorrect Django references to Flask

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -629,17 +629,17 @@ Flask cache data storage
     def login():
         ...
         launch_data_storage = FlaskCacheDataStorage(cache)
-        oidc_login = DjangoOIDCLogin(request, tool_conf, launch_data_storage=launch_data_storage)
+        oidc_login = FlaskOIDCLogin(request, tool_conf, launch_data_storage=launch_data_storage)
 
     def launch():
         ...
         launch_data_storage = FlaskCacheDataStorage(cache)
-        message_launch = DjangoMessageLaunch(request, tool_conf, launch_data_storage=launch_data_storage)
+        message_launch = FlaskMessageLaunch(request, tool_conf, launch_data_storage=launch_data_storage)
 
     def restore_launch():
         ...
         launch_data_storage = FlaskCacheDataStorage(cache)
-        message_launch = DjangoMessageLaunch.from_cache(launch_id, request, tool_conf,
+        message_launch = FlaskMessageLaunch.from_cache(launch_id, request, tool_conf,
                                                         launch_data_storage=launch_data_storage)
 
 Cache for Public Key


### PR DESCRIPTION
Fixes issue #121. The documentation was changed to refer to the correct Flask methods.


> In the `README.rst`, the following reference block for Flask refers to DjangoOIDCLogin and DjangoMessageLaunch methods:
> 
> **Flask cache data storage**
> ```
> from flask_caching import Cache
> from pylti1p3.contrib.flask import FlaskCacheDataStorage
> 
> cache = Cache(app)
> 
> def login():
>     ...
>     launch_data_storage = FlaskCacheDataStorage(cache)
>     oidc_login = DjangoOIDCLogin(request, tool_conf, launch_data_storage=launch_data_storage)
> 
> def launch():
>     ...
>     launch_data_storage = FlaskCacheDataStorage(cache)
>     message_launch = DjangoMessageLaunch(request, tool_conf, launch_data_storage=launch_data_storage)
> 
> def restore_launch():
>     ...
>     launch_data_storage = FlaskCacheDataStorage(cache)
>     message_launch = DjangoMessageLaunch.from_cache(launch_id, request, tool_conf,
>                                                     launch_data_storage=launch_data_storage)
> ```

