### PR TITLE
Fix missing cookie exception message

### DIFF
--- a/pylti1p3/message_launch.py
+++ b/pylti1p3/message_launch.py
@@ -775,7 +775,7 @@ class MessageLaunch(t.Generic[REQ, TCONF, SES, COOK]):
             if session_id:
                 data_storage.set_session_id(session_id)
             else:
-                raise LtiException(f"Missing %s cookie {session_cookie_name}")
+                raise LtiException(f"Missing cookie: {session_cookie_name}")
         self._session_service.set_data_storage(data_storage)
         return self
 


### PR DESCRIPTION
The `%s` in this string is being rendered out and not being used for the variable given to this f-string.