### PR TITLE
Remove universal wheel config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal=1
-
 [metadata]
 description-file = README.rst
 license_file = LICENSE


### PR DESCRIPTION
This shouldn't be necessary now that we're not on python 2 anymore.