### PR TITLE
ServiceConnector.make_service_request: don't convert the next_page_url to lowercase

### DIFF
--- a/pylti1p3/service_connector.py
+++ b/pylti1p3/service_connector.py
@@ -132,7 +132,8 @@ class ServiceConnector:
         if link_header:
             match = re.search(
                 r'<([^>]*)>;\s*rel="next"',
-                link_header.replace("\n", " ").lower().strip(),
+                link_header.replace("\n", " ").strip(),
+                re.IGNORECASE
             )
             if match:
                 next_page_url = match.group(1)


### PR DESCRIPTION
The code to pull out the next page URL from the `Link` header converted the text to lowercase, leading to returning an incorrect URL when the original used uppercase characters.

This changes the regex to use the `re.IGNORECASE` flag instead of converting the string to lowercase.